### PR TITLE
Fix bruteforce bypass #13 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -68,6 +68,12 @@ function userExists({ couchdb, name }, throwNotFound = true) {
 }
 
 function checkBruteforce({ redis, ip }) {
+  if(process.env.MAX_FORWARD_COUNT){
+	let ipList = ip.split(',');
+	ipList = ipList.slice(0, (parseInt(process.env.MAX_FORWARD_COUNT, 10) + 1);
+	ip = ipList.join(',');
+	Console.log('Checked : '+ip);
+  }
   let tries;
   return redis
     .getAsync(`bf_${ip}`)


### PR DESCRIPTION
Avoid concatenatation of fake IP in X-Forwarded-For for bruteforce attack like described in #13 

Use env var MAX_FORWARD_COUNT to set the max XFF count.

So if the API is just behind 1 reverse proxy, set MAX_FORWARD_COUNT=1, and the bruteforce check will only take the 2 firsts IP of the X-Forwarded-For.